### PR TITLE
Convert images to RGB if not RGB

### DIFF
--- a/package_files/nsfw_detector/image_utils.py
+++ b/package_files/nsfw_detector/image_utils.py
@@ -23,6 +23,8 @@ if pil_image is not None:
 # loads an image and performs the transformations 
 def load_image(path, dtype="float32"):
     img = pil_image.open(path)
+    if img.mode != 'RGB':
+        img = img.convert('RGB')
     size = 240
     img = img.resize((size,size))
     x = np.asarray(img, dtype=dtype)


### PR DESCRIPTION
It previously gives an error if I load a PNG with alpha channel, or a gray-scale JPEG.